### PR TITLE
fix: add delay in Dispose method to prevent API server throttling

### DIFF
--- a/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go
+++ b/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go
@@ -531,6 +531,9 @@ func (m *NetworkPolicySoakMeasurement) Dispose() {
 		if err := m.k8sClient.AppsV1().Deployments(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector}); err != nil {
 			klog.Errorf("phase: gather, %s NS: %s, failed to delete target deployments: %v", m.String(), ns, err)
 		}
+		// add a delay to avoid API server throttling,
+		// wait for number of replicas per target namespace * 0.1 seconds
+		time.Sleep(time.Duration(m.targetReplicasPerNs) * 100 * time.Millisecond)
 	}
 
 	// stop gatherers


### PR DESCRIPTION
This pull request includes an important change to the `Dispose` method in the `NetworkPolicySoakMeasurement` class to address API server throttling issues.

Codebase improvement:

* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fR534-R536): Added a delay after deleting target deployments to avoid API server throttling by waiting for the number of replicas per target namespace multiplied by 0.1 seconds.