### PR TITLE
refactor: replace time.Sleep with timer in gather method and adjust d…

### DIFF
--- a/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go
+++ b/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go
@@ -420,7 +420,10 @@ func (m *NetworkPolicySoakMeasurement) gather() ([]measurement.Summary, error) {
 
 	// wait for the test to complete
 	klog.Infof("phase: gather, %s: waiting for the test run to complete...", m.String())
-	time.Sleep(time.Until(m.testEndTime))
+	// Instead of: time.Sleep(time.Until(m.testEndTime))
+	timer := time.NewTimer(time.Until(m.testEndTime))
+	<-timer.C
+	// Optionally, call timer.Stop() if needed.
 	klog.Infof("phase: gather, %s: test run completed", m.String())
 
 	// if resource gathering is not enabled, skip the gathering
@@ -532,8 +535,8 @@ func (m *NetworkPolicySoakMeasurement) Dispose() {
 			klog.Errorf("phase: gather, %s NS: %s, failed to delete target deployments: %v", m.String(), ns, err)
 		}
 		// add a delay to avoid API server throttling,
-		// wait for number of replicas per target namespace * 0.1 seconds
-		time.Sleep(time.Duration(m.targetReplicasPerNs) * 100 * time.Millisecond)
+		// wait for 500ms before deleting the next deployment
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	// stop gatherers


### PR DESCRIPTION
This pull request includes improvements to the timing mechanisms in the `NetworkPolicySoakMeasurement` class to make the code more efficient and easier to understand.

Timing mechanism improvements:

* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL423-R426): Replaced `time.Sleep` with `time.NewTimer` to wait for the test run to complete in the `gather` method. This change allows for more precise control of the timing and the potential to stop the timer if needed.
* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL535-R539): Updated the `Dispose` method to use a fixed 500ms delay between deleting deployments, instead of a variable delay based on the number of replicas. This simplifies the timing logic and avoids potential API server throttling.