### PR TITLE
Ado 30677283 selective merge

### DIFF
--- a/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/client_deploy.yaml
+++ b/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/client_deploy.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   labels:
     {{ (StructuralData .ClientLabelKey)}}: {{.ClientLabelValue}}
+    # this is dynamically generated and used for group deployment and deletion tracking
+    {{ (StructuralData .ClientDeploymentLabelKey)}}: {{.ClientDeploymentLabelValue}}
   name: {{.UniqueName}}
   namespace: {{.ClientNamespace}}
 spec:
@@ -10,10 +12,12 @@ spec:
   selector:
     matchLabels:
       {{ (StructuralData .ClientLabelKey)}}: {{.ClientLabelValue}}
+      {{ (StructuralData .ClientDeploymentLabelKey)}}: {{.ClientDeploymentLabelValue}}
   template:
     metadata:
       labels:
         {{ (StructuralData .ClientLabelKey)}}: {{.ClientLabelValue}}
+        {{ (StructuralData .ClientDeploymentLabelKey)}}: {{.ClientDeploymentLabelValue}}
     spec:
       nodeSelector:
         node: "client"

--- a/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/target_deploy.yaml
+++ b/clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/target_deploy.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   labels:
     {{ (StructuralData .TargetLabelKey)}}: {{.TargetLabelValue}}
+    # this is dynamically generated and used for group deployment and deletion tracking
+    {{ (StructuralData .TargetDeploymentLabelKey)}}: {{.TargetDeploymentLabelValue}}
   name: {{.TargetName}}
   namespace: {{.TargetNamespace}}
 spec:
@@ -10,10 +12,12 @@ spec:
   selector:
     matchLabels:
       {{ (StructuralData .TargetLabelKey)}}: {{.TargetLabelValue}}
+      {{ (StructuralData .TargetDeploymentLabelKey)}}: {{.TargetDeploymentLabelValue}}
   template:
     metadata:
       labels:
-        app: target
+        {{ (StructuralData .TargetLabelKey)}}: {{.TargetLabelValue}}
+        {{ (StructuralData .TargetDeploymentLabelKey)}}: {{.TargetDeploymentLabelValue}}
     spec:
       nodeSelector:
         slo: "true"


### PR DESCRIPTION
This pull request includes several changes to the `clusterloader2/pkg/measurement/common/network-policy/network-policy-soak` package to improve the deployment and tracking of network policy soak tests. The most important changes include adding dynamic labels for deployment tracking, validating replica counts, and creating unique template maps for batch deployments.

Improvements to deployment tracking:

* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/client_deploy.yaml`](diffhunk://#diff-9677ee6dd3d88f2bb57d3896779b02b5dba9f90b8a065f18a01a6ebc048e005eR6-R20): Added dynamically generated labels for group deployment and deletion tracking.
* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/manifests/target_deploy.yaml`](diffhunk://#diff-67f2c3fd4e440a486da70b8f8ab12d270cce70bbefd6c9317747ea595803edfbR6-R20): Added dynamically generated labels for group deployment and deletion tracking.

Enhancements to deployment logic:

* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL242-R244): Added validation to ensure the replica count is positive in `deployTargetPods`.
* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fR253-R277): Created new template maps per batch in `deployTargetPods` and `deployClientPods` to avoid reuse issues and generate unique keys and values for each deployment batch. [[1]](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fR253-R277) [[2]](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL355-R384)

Code cleanup:

* [`clusterloader2/pkg/measurement/common/network-policy/network-policy-soak/np_soak_measurment.go`](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL313): Removed unnecessary blank lines in `deployNetworkPolicy`. [[1]](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL313) [[2]](diffhunk://#diff-72318cbdb4c1b61f844c5c7d882c8ebdf012963d68dc23bb42a7318f27bc162fL324)