### PR TITLE
http2 server - plaintext

### DIFF
--- a/network/benchmarks/H2Playground/Dockerfile
+++ b/network/benchmarks/H2Playground/Dockerfile
@@ -1,0 +1,24 @@
+# Build image
+FROM golang:1.23 AS build-env
+
+ARG gopkg=k8s.io/perf-tests/network/benchmarks/H2Playground
+ADD ["./", "/go/src/${gopkg}"]
+WORKDIR /go/src/${gopkg}
+RUN ls -la
+
+RUN CGO_ENABLED=0 go build -o /h2playground ./cmd/h2server/main.go
+
+# Runtime image
+FROM alpine:3.20
+# install curl
+RUN apk add --no-cache curl
+
+# install tcpdump
+RUN apk add --no-cache tcpdump
+
+COPY --from=build-env /h2playground /h2playground
+
+#Make sure that when compiled on debian, the binary will run on alpine
+RUN mkdir -p /lib64 && ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+ENTRYPOINT ["/h2playground"]

--- a/network/benchmarks/H2Playground/Makefile
+++ b/network/benchmarks/H2Playground/Makefile
@@ -1,0 +1,17 @@
+USERNAME ?= sanamsarath
+PROJECT ?= h2playground
+REGISTRY ?= acnpublic.azurecr.io
+IMG ?= $(USERNAME)/$(PROJECT)
+TAG ?= 0.3
+
+all: push
+
+.PHONY: build
+build:
+	docker build --pull -t $(REGISTRY)/$(IMG):$(TAG) .
+	@echo "Built $(IMG):$(TAG)"
+
+.PHONY: push
+push: build
+	docker push $(REGISTRY)/$(IMG):$(TAG)
+	@echo "Pushed $(IMG):$(TAG)"

--- a/network/benchmarks/H2Playground/cmd/h2server/main.go
+++ b/network/benchmarks/H2Playground/cmd/h2server/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"k8s.io/perf-tests/network/benchmarks/H2Playground/pkg/server"
+)
+
+func main() {
+	if err := server.Start(); err != nil {
+		log.Fatalf("Server exited with error: %v", err)
+	}
+}

--- a/network/benchmarks/H2Playground/go.mod
+++ b/network/benchmarks/H2Playground/go.mod
@@ -1,0 +1,14 @@
+module k8s.io/perf-tests/network/benchmarks/H2Playground
+
+go 1.23.3
+
+require (
+	golang.org/x/net v0.35.0
+	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.130.1
+)
+
+require (
+	github.com/go-logr/logr v1.4.1 // indirect
+	golang.org/x/text v0.22.0 // indirect
+)

--- a/network/benchmarks/H2Playground/go.sum
+++ b/network/benchmarks/H2Playground/go.sum
@@ -1,0 +1,11 @@
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
+golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=

--- a/network/benchmarks/H2Playground/pkg/server/server.go
+++ b/network/benchmarks/H2Playground/pkg/server/server.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"flag" // added flag import
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	klog "k8s.io/klog/v2"
+)
+
+func setKlogLevelHandler(w http.ResponseWriter, r *http.Request) {
+	levelStr := r.URL.Query().Get("level")
+	if levelStr == "" {
+		http.Error(w, "missing 'level' parameter", http.StatusBadRequest)
+		return
+	}
+	level, err := strconv.Atoi(levelStr)
+	if err != nil {
+		http.Error(w, "invalid 'level' parameter", http.StatusBadRequest)
+		return
+	}
+	// Update klog verbosity
+	if f := flag.Lookup("v"); f != nil {
+		if err := f.Value.Set(levelStr); err != nil {
+			http.Error(w, "failed to update log level", http.StatusInternalServerError)
+			return
+		}
+		klog.Infof("Updated klog level to %d", level)
+		w.Write([]byte("klog level updated"))
+	} else {
+		http.Error(w, "flag 'v' not found", http.StatusInternalServerError)
+	}
+}
+
+// Start initializes and runs both plain text (h2c) and TLS HTTP/2 servers.
+// It now parses port flags: -plain and -tls.
+func Start() error {
+	// Initialize klog flags to register "v"
+	klog.InitFlags(nil)
+	defer klog.Flush()
+
+	// Parse flags for ports.
+	plainPort := flag.String("plain", "8080", "Port for plain text (h2c) server")
+	tlsPort := flag.String("tls", "8443", "Port for TLS server")
+	flag.Parse()
+
+	// Common handler responds with the greeting and HTTP protocol used.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if klog.V(2).Enabled() {
+			klog.Infof("Received request from %s, protocol: %s, method: %s", r.RemoteAddr, r.Proto, r.Method)
+		}
+	})
+
+	// HTTP/2 cleartext (plain text) server with h2c.
+	plainServer := &http.Server{
+		Addr:    ":" + *plainPort,
+		Handler: h2c.NewHandler(handler, &http2.Server{}),
+	}
+
+	// TLS HTTP/2 server; TLS config auto-enables HTTP/2.
+	tlsServer := &http.Server{
+		Addr:    ":" + *tlsPort,
+		Handler: handler,
+	}
+
+	// Register handler to update klog level
+	http.HandleFunc("/set-klog", setKlogLevelHandler)
+	klog.Info("Starting server on :8090")
+	go func() {
+		if err := http.ListenAndServe(":8090", nil); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("Server error: %v", err)
+		}
+	}()
+
+	// Run the plain text server concurrently.
+	go func() {
+		log.Println("Starting HTTP/2 (h2c) server on port", *plainPort)
+		if err := plainServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("Plain server error: %v", err)
+		}
+	}()
+
+	// Run the TLS server concurrently.
+	go func() {
+		log.Println("Starting HTTP/2 TLS server on port", *tlsPort)
+		// Update certificate paths as needed.
+		if err := tlsServer.ListenAndServeTLS("server.crt", "server.key"); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("TLS server error: %v", err)
+		}
+	}()
+
+	// Wait for OS termination signal.
+	waitForShutdown(plainServer, tlsServer)
+	return nil
+}
+
+// waitForShutdown listens for SIGINT and SIGTERM signals to gracefully shutdown servers.
+func waitForShutdown(servers ...*http.Server) {
+	// Listen for incoming OS signals.
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	<-stop
+
+	// Begin graceful shutdown.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, srv := range servers {
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("Shutdown error: %v", err)
+		}
+	}
+
+	// wait for all servers to shutdown
+	<-ctx.Done()
+	log.Println("Servers shut down gracefully")
+}


### PR DESCRIPTION
This pull request introduces a new HTTP/2 benchmarking tool called `H2Playground`, including its Docker setup, build pipeline, and core functionality. The changes span multiple files, implementing a server with both plain text (h2c) and TLS HTTP/2 support, a Dockerfile for containerization, and a Makefile for building and pushing the Docker image.

### Server Implementation
* Added a new HTTP/2 server in `pkg/server/server.go` with support for both plain text (h2c) and TLS. The server includes a handler to dynamically update `klog` verbosity levels and gracefully shuts down on receiving termination signals.
* Created the main entry point for the server in `cmd/h2server/main.go`, which initializes and starts the server.

### Build and Deployment
* Added a `Dockerfile` to build and run the `H2Playground` server in a container. It uses a multi-stage build process with a Golang build image and an Alpine runtime image.
* Introduced a `Makefile` to simplify building and pushing the Docker image. It supports customizable parameters like username, project name, registry, and tag.

### Dependency Management
* Added a `go.mod` file to define the module and its dependencies, including `golang.org/x/net` for HTTP/2 support and `k8s.io/klog/v2` for logging.
